### PR TITLE
Move to static nginx without node

### DIFF
--- a/config/oim.conf
+++ b/config/oim.conf
@@ -1,13 +1,38 @@
 server {
-	listen 80;
+        listen 80;
 	listen [::]:80;
 
-	server_name openstreetmap.doriangaliana.fr;
+        root /opt/oim-web/dist;
+        index index.html;
 
-	location / {
-		proxy_pass http://localhost:8080/;
-	}
-	location /tiles/ {
-		proxy_pass http://localhost:8081/maps/openinframap/;
-	}
+        server_name openstreetmap.doriangaliana.fr;
+        gzip on;
+        gzip_proxied any;
+        gzip_types application/x-protobuf application/json application/javascript;
+
+        location /tiles {
+                if ($uri ~ "/tiles/[0-6]/") {
+                        expires 24h;
+                }
+                if ($uri ~ "/tiles/[7-9]/") {
+                        expires 6h;
+                }
+                if ($uri ~ "/tiles/(10|11|12|13|14|15|16)/") {
+                        expires 30m;
+                }
+                proxy_pass http://127.0.0.1:8081/maps/openinframap;
+        }
+
+        location ~ \.json$ {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        }
+
+        location ~ \.js$ {
+                expires 30d;
+        }
+
+        location / {
+                try_files $uri $uri/ =404;
+        }
 }


### PR DESCRIPTION
Suppression du besoin de nodejs pour servir le front : ca passe directement via nginx